### PR TITLE
Display combat log in UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -107,3 +107,17 @@ input[type="radio"]:checked + label {
 .combat-button:last-child {
   margin-right: 0;
 }
+
+.combat-log {
+  max-height: 200px;
+  overflow-y: auto;
+  background-color: #f3f3f3;
+  padding: 10px;
+  margin-top: 20px;
+  text-align: left;
+  border: 1px solid #ccc;
+}
+
+.combat-log p {
+  margin: 2px 0;
+}


### PR DESCRIPTION
## Summary
- add combat log state with helper
- surface round outcomes and kills in a log on screen
- style new combat log area

## Testing
- `CI=true npm test --silent -- --runTestsByPath src/__tests__/deck.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684182edb0c08323b9920ea122a8e7f5