### PR TITLE
Add initiative display and spacing for combat log

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -61,6 +61,9 @@ const handleCombatRound = (player1card, player2card, player1Choice, player2Choic
   const player1Initiative = player1card.stats.agility * 0.4 + player1card.stats.intelligence * 0.6 + Math.floor(Math.random() * 21);
   const player2Initiative = player2card.stats.agility * 0.4 + player2card.stats.intelligence * 0.6 + Math.floor(Math.random() * 21);
 
+  logFn(`${player1card.name} initiative: ${player1Initiative}`);
+  logFn(`${player2card.name} initiative: ${player2Initiative}`);
+
   let firstAttacker, secondAttacker;
   let firstChoice, secondChoice;
 
@@ -76,8 +79,12 @@ const handleCombatRound = (player1card, player2card, player1Choice, player2Choic
     secondChoice = player1Choice;
   }
 
+  logFn(`${firstAttacker.name} goes first`);
+
   // First Attacker Round (higher initiative)
   let outcome1 = combatRound(firstAttacker, secondAttacker, firstChoice, logFn);
+
+  logFn('');
 
   // Check for a winner after first attack
   const result1 = victoryCheck(player1card, player2card);
@@ -187,6 +194,10 @@ function Game() {
   // - Call combat functions
   // - Victory conditions (for a combat round) check
   const Fight = () => {
+    if (round > 1) {
+      addLog('');
+      addLog('');
+    }
     addLog(`--- Round ${round} ---`);
 
     const outcome = handleCombatRound(


### PR DESCRIPTION
## Summary
- add initiative log output so players can see scores
- indicate who attacks first
- insert blank line between player attack logs
- insert two blank lines between rounds

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418b404e488323971cc0807a46c768