### PR TITLE
Adjust combat log spacing

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -80,6 +80,7 @@ const handleCombatRound = (player1card, player2card, player1Choice, player2Choic
   }
 
   logFn(`${firstAttacker.name} goes first`);
+  logFn('');
 
   // First Attacker Round (higher initiative)
   let outcome1 = combatRound(firstAttacker, secondAttacker, firstChoice, logFn);
@@ -94,6 +95,8 @@ const handleCombatRound = (player1card, player2card, player1Choice, player2Choic
 
   // Second Attacker Round (if no winner yet)
   let outcome2 = combatRound(secondAttacker, firstAttacker, secondChoice, logFn);
+  logFn('');
+  logFn('');
 
   // Check again for a winner after the second attack
   const result2 = victoryCheck(player1card, player2card);
@@ -194,10 +197,6 @@ function Game() {
   // - Call combat functions
   // - Victory conditions (for a combat round) check
   const Fight = () => {
-    if (round > 1) {
-      addLog('');
-      addLog('');
-    }
     addLog(`--- Round ${round} ---`);
 
     const outcome = handleCombatRound(


### PR DESCRIPTION
## Summary
- improve readability in the combat log
- keep rounds separated by logging blank lines after attacks

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68419331d43083239af5f19579358afd