### PR TITLE
Add health bar and responsive card styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -93,6 +93,8 @@ input[type="radio"]:checked + label {
   flex-direction: column;
   text-align: center;
   position: relative;
+  width: 220px;
+  max-width: 100%;
 }
 
 .card h2 {
@@ -105,6 +107,32 @@ input[type="radio"]:checked + label {
   padding: 0;
   font-size: 0.9em; /* Smaller font for stats */
   list-style-type: none; /* remove bullet points */
+}
+
+.health-bar {
+  position: relative;
+  width: 100%;
+  height: 14px;
+  background-color: #ddd;
+  border-radius: 7px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.health-bar-fill {
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.health-bar-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 0.75em;
+  font-weight: bold;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
 }
 
 /* when a card is selected */
@@ -191,23 +219,24 @@ input[type="radio"]:checked + label {
   min-height: 1em; /* Ensures even empty paragraphs create space */
 }
 
-.card-hp-circle {
-  position: absolute;
-  top: -10px;
-  right: -10px;
-  background-color: #e74c3c;
-  color: white;
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.1em;
-  font-weight: bold;
-  border: 2px solid white;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-  z-index: 10;
+@media (max-width: 768px) {
+  .card {
+    width: 180px;
+  }
+  .creature-image {
+    width: 180px !important;
+    max-height: 180px;
+  }
+}
+
+@media (max-width: 480px) {
+  .card {
+    width: 140px;
+  }
+  .creature-image {
+    width: 140px !important;
+    max-height: 140px;
+  }
 }
 
 @media (max-width: 1200px) {

--- a/src/Card.js
+++ b/src/Card.js
@@ -1,17 +1,27 @@
 import React from 'react';
 
 function Card({ creature, onCardSelect, isSelected }) {
+  const healthPercent = (creature.currentHealth / creature.maxHealth) * 100;
+  const barColor = `hsl(${healthPercent * 1.2}, 70%, 50%)`;
 
   return (
     <div className={`card ${isSelected ? 'selected' : ''}`} onClick={onCardSelect}>
-      <div className="card-hp-circle">{creature.currentHealth}</div>
+      <div className="health-bar">
+        <div
+          className="health-bar-fill"
+          style={{ width: `${healthPercent}%`, backgroundColor: barColor }}
+        ></div>
+        <span className="health-bar-text">
+          {creature.currentHealth} / {creature.maxHealth}
+        </span>
+      </div>
       <h2>{creature.name}</h2>
       <img src={creature.image} alt={creature.name} className="creature-image" />
 
       <ul>
         {Object.keys(creature.stats).map(stat => (
           <li key={stat}>
-                {stat}: {creature.stats[stat]}
+            {stat}: {creature.stats[stat]}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- Replace HP circle with dynamic health bar showing current and max HP
- Style health bar with color cues and responsive card layout

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6894f7d2713c8323af70cc675abd74f9