### PR TITLE
Add deck builder game mode

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Game from './Game';
 import DeckBuilder from './DeckBuilder';
+import { DECK_SIZE } from './constants';
 import './App.css';
 
 function App() {
@@ -13,7 +14,7 @@ function App() {
     setPlayer2Deck(p2);
   };
 
-  if (mode === 'custom' && (player1Deck.length !== 3 || player2Deck.length !== 3)) {
+  if (mode === 'custom' && (player1Deck.length !== DECK_SIZE || player2Deck.length !== DECK_SIZE)) {
     return (
       <div className="App">
         <DeckBuilder onDecksSelected={handleDecksSelected} />
@@ -31,7 +32,7 @@ function App() {
         </div>
       )}
       {mode === 'random' && <Game />}
-      {mode === 'custom' && player1Deck.length === 3 && player2Deck.length === 3 && (
+      {mode === 'custom' && player1Deck.length === DECK_SIZE && player2Deck.length === DECK_SIZE && (
         <Game player1Deck={player1Deck} player2Deck={player2Deck} />
       )}
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,39 @@
-import React from 'react';
-import Game from './Game';  // Import the game component
-import './App.css';  // CSS file
-
+import React, { useState } from 'react';
+import Game from './Game';
+import DeckBuilder from './DeckBuilder';
+import './App.css';
 
 function App() {
+  const [mode, setMode] = useState(null); // 'random' or 'custom'
+  const [player1Deck, setPlayer1Deck] = useState([]);
+  const [player2Deck, setPlayer2Deck] = useState([]);
+
+  const handleDecksSelected = (p1, p2) => {
+    setPlayer1Deck(p1);
+    setPlayer2Deck(p2);
+  };
+
+  if (mode === 'custom' && (player1Deck.length !== 3 || player2Deck.length !== 3)) {
+    return (
+      <div className="App">
+        <DeckBuilder onDecksSelected={handleDecksSelected} />
+      </div>
+    );
+  }
+
   return (
     <div className="App">
-      <Game />
+      {mode === null && (
+        <div>
+          <h2>Select Game Mode</h2>
+          <button onClick={() => setMode('random')}>Random Decks</button>
+          <button onClick={() => setMode('custom')}>Choose Decks</button>
+        </div>
+      )}
+      {mode === 'random' && <Game />}
+      {mode === 'custom' && player1Deck.length === 3 && player2Deck.length === 3 && (
+        <Game player1Deck={player1Deck} player2Deck={player2Deck} />
+      )}
     </div>
   );
 }

--- a/src/DeckBuilder.js
+++ b/src/DeckBuilder.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import creatures from './creatures';
+import { DECK_SIZE } from './constants';
 
 function DeckBuilder({ onDecksSelected }) {
   const [player1Deck, setPlayer1Deck] = useState([]);
@@ -15,8 +16,8 @@ function DeckBuilder({ onDecksSelected }) {
     if (isSelected) {
       newDeck = deck.filter(c => c.name !== creature.name);
     } else {
-      if (deck.length >= 3) {
-        setError(`Player ${player} already has 3 creatures.`);
+      if (deck.length >= DECK_SIZE) {
+        setError(`Player ${player} already has ${DECK_SIZE} creatures.`);
         return;
       }
       newDeck = [...deck, creature];
@@ -26,13 +27,13 @@ function DeckBuilder({ onDecksSelected }) {
   };
 
   const finalizeDecks = () => {
-    if (player1Deck.length !== 3 || player2Deck.length !== 3) {
-      setError('Each player must select exactly 3 creatures.');
+    if (player1Deck.length !== DECK_SIZE || player2Deck.length !== DECK_SIZE) {
+      setError(`Each player must select exactly ${DECK_SIZE} creatures.`);
       return;
     }
     const unique1 = new Set(player1Deck.map(c => c.name));
     const unique2 = new Set(player2Deck.map(c => c.name));
-    if (unique1.size !== 3 || unique2.size !== 3) {
+    if (unique1.size !== DECK_SIZE || unique2.size !== DECK_SIZE) {
       setError('Duplicate selections are not allowed.');
       return;
     }
@@ -45,7 +46,7 @@ function DeckBuilder({ onDecksSelected }) {
   const renderCreature = (creature, player) => {
     const deck = player === 1 ? player1Deck : player2Deck;
     const isSelected = deck.some(c => c.name === creature.name);
-    const disabled = deck.length >= 3 && !isSelected;
+    const disabled = deck.length >= DECK_SIZE && !isSelected;
     return (
       <label key={`${player}-${creature.name}`} style={{display: 'block'}}>
         <input

--- a/src/DeckBuilder.js
+++ b/src/DeckBuilder.js
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import creatures from './creatures';
+
+function DeckBuilder({ onDecksSelected }) {
+  const [player1Deck, setPlayer1Deck] = useState([]);
+  const [player2Deck, setPlayer2Deck] = useState([]);
+  const [error, setError] = useState('');
+
+  const toggleSelection = (player, creature) => {
+    const deck = player === 1 ? player1Deck : player2Deck;
+    const setDeck = player === 1 ? setPlayer1Deck : setPlayer2Deck;
+    const isSelected = deck.some(c => c.name === creature.name);
+
+    let newDeck;
+    if (isSelected) {
+      newDeck = deck.filter(c => c.name !== creature.name);
+    } else {
+      if (deck.length >= 3) {
+        setError(`Player ${player} already has 3 creatures.`);
+        return;
+      }
+      newDeck = [...deck, creature];
+    }
+    setError('');
+    setDeck(newDeck);
+  };
+
+  const finalizeDecks = () => {
+    if (player1Deck.length !== 3 || player2Deck.length !== 3) {
+      setError('Each player must select exactly 3 creatures.');
+      return;
+    }
+    const unique1 = new Set(player1Deck.map(c => c.name));
+    const unique2 = new Set(player2Deck.map(c => c.name));
+    if (unique1.size !== 3 || unique2.size !== 3) {
+      setError('Duplicate selections are not allowed.');
+      return;
+    }
+    setError('');
+    // Deep copy to avoid modifying the original objects during the game
+    const copyDeck = deck => deck.map(c => JSON.parse(JSON.stringify(c)));
+    onDecksSelected(copyDeck(player1Deck), copyDeck(player2Deck));
+  };
+
+  const renderCreature = (creature, player) => {
+    const deck = player === 1 ? player1Deck : player2Deck;
+    const isSelected = deck.some(c => c.name === creature.name);
+    const disabled = deck.length >= 3 && !isSelected;
+    return (
+      <label key={`${player}-${creature.name}`} style={{display: 'block'}}>
+        <input
+          type="checkbox"
+          checked={isSelected}
+          disabled={disabled}
+          onChange={() => toggleSelection(player, creature)}
+        />
+        {creature.name}
+      </label>
+    );
+  };
+
+  return (
+    <div>
+      <h2>Deck Builder</h2>
+      <div style={{display: 'flex', justifyContent: 'space-around'}}>
+        <div>
+          <h3>Player 1</h3>
+          {creatures.map(creature => renderCreature(creature, 1))}
+        </div>
+        <div>
+          <h3>Player 2</h3>
+          {creatures.map(creature => renderCreature(creature, 2))}
+        </div>
+      </div>
+      {error && <p style={{color: 'red'}}>{error}</p>}
+      <button onClick={finalizeDecks}>Start Game</button>
+    </div>
+  );
+}
+
+export default DeckBuilder;

--- a/src/Game.js
+++ b/src/Game.js
@@ -142,11 +142,21 @@ function combatRound(attacker, defender, combatChoice, logFn) {
 
 
 // Main Game function
-function Game() {
+function Game({ player1Deck, player2Deck }) {
 
   // Initialize player hands using useState
-  const [player1Hand, setPlayer1Hand] = useState(() => getThreeUniqueCards(creatures));
-  const [player2Hand, setPlayer2Hand] = useState(() => getThreeUniqueCards(creatures));
+  const [player1Hand, setPlayer1Hand] = useState(() => {
+    if (player1Deck && player1Deck.length === 3) {
+      return player1Deck.map(card => JSON.parse(JSON.stringify(card)));
+    }
+    return getThreeUniqueCards(creatures);
+  });
+  const [player2Hand, setPlayer2Hand] = useState(() => {
+    if (player2Deck && player2Deck.length === 3) {
+      return player2Deck.map(card => JSON.parse(JSON.stringify(card)));
+    }
+    return getThreeUniqueCards(creatures);
+  });
 
   // Selected card in each hand
   const [player1SelectedCard, setPlayer1SelectedCard] = useState(null);

--- a/src/Game.js
+++ b/src/Game.js
@@ -2,24 +2,25 @@ import React, { useState, useEffect } from 'react';
 import creatures from './creatures';  // Import the creatures data
 import Card from './Card';  // Import the Card component
 import Modal from './Modal'; // Import the Modal component
+import { DECK_SIZE } from './constants';
 
 
 // Deck Creation
-// - draw 3 unique cards
-const getThreeUniqueCards = (creatures) => {
+// - draw a number of unique cards
+const getRandomUniqueCards = (creaturesList, count) => {
   const selectedIndices = new Set();  // Use a set to store unique indices
   const selectedCards = [];
 
-  // Continue generating indices until we have 3 unique ones
-  while (selectedIndices.size < 3) {
-    const randomIndex = Math.floor(Math.random() * creatures.length);
+  // Continue generating indices until we have the desired number of unique ones
+  while (selectedIndices.size < count) {
+    const randomIndex = Math.floor(Math.random() * creaturesList.length);
 
     // If this index has not been selected yet, add it to the set and push the creature
     if (!selectedIndices.has(randomIndex)) {
       selectedIndices.add(randomIndex);
 
       // Create a deep copy of the selected creature
-      const creatureCopy = JSON.parse(JSON.stringify(creatures[randomIndex]));
+      const creatureCopy = JSON.parse(JSON.stringify(creaturesList[randomIndex]));
       selectedCards.push(creatureCopy);
     }
   }
@@ -146,16 +147,16 @@ function Game({ player1Deck, player2Deck }) {
 
   // Initialize player hands using useState
   const [player1Hand, setPlayer1Hand] = useState(() => {
-    if (player1Deck && player1Deck.length === 3) {
+    if (player1Deck && player1Deck.length === DECK_SIZE) {
       return player1Deck.map(card => JSON.parse(JSON.stringify(card)));
     }
-    return getThreeUniqueCards(creatures);
+    return getRandomUniqueCards(creatures, DECK_SIZE);
   });
   const [player2Hand, setPlayer2Hand] = useState(() => {
-    if (player2Deck && player2Deck.length === 3) {
+    if (player2Deck && player2Deck.length === DECK_SIZE) {
       return player2Deck.map(card => JSON.parse(JSON.stringify(card)));
     }
-    return getThreeUniqueCards(creatures);
+    return getRandomUniqueCards(creatures, DECK_SIZE);
   });
 
   // Selected card in each hand
@@ -413,4 +414,4 @@ function Game({ player1Deck, player2Deck }) {
 }
 
 export default Game;
-export { getThreeUniqueCards };
+export { getRandomUniqueCards };

--- a/src/__tests__/deck.test.js
+++ b/src/__tests__/deck.test.js
@@ -1,6 +1,7 @@
-import { getThreeUniqueCards } from '../Game';
+import { getRandomUniqueCards } from '../Game';
+import { DECK_SIZE } from '../constants';
 
-describe('getThreeUniqueCards', () => {
+describe('getRandomUniqueCards', () => {
   const sampleCreatures = [
     { name: 'A' },
     { name: 'B' },
@@ -8,15 +9,15 @@ describe('getThreeUniqueCards', () => {
     { name: 'D' }
   ];
 
-  test('returns an array of length 3', () => {
-    const cards = getThreeUniqueCards(sampleCreatures);
-    expect(cards).toHaveLength(3);
+  test('returns an array of specified length', () => {
+    const cards = getRandomUniqueCards(sampleCreatures, DECK_SIZE);
+    expect(cards).toHaveLength(DECK_SIZE);
   });
 
   test('returns unique cards', () => {
-    const cards = getThreeUniqueCards(sampleCreatures);
+    const cards = getRandomUniqueCards(sampleCreatures, DECK_SIZE);
     const names = cards.map(c => c.name);
     const uniqueNames = new Set(names);
-    expect(uniqueNames.size).toBe(3);
+    expect(uniqueNames.size).toBe(DECK_SIZE);
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const DECK_SIZE = 3;


### PR DESCRIPTION
## Summary
- add DeckBuilder component for selecting three creatures per player
- support random or player-selected decks in App
- allow Game to use selected decks when available

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6894fb10836483238a4155d34caec139