### PR TITLE
Display cards in deck builder

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -198,6 +198,27 @@ input[type="radio"]:checked + label {
   border: 4px solid black;
 }
 
+.card.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.deck-builder .player-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.deck-builder .card {
+  width: 180px;
+}
+
+.deck-builder .creature-image {
+  width: 100% !important;
+  max-height: 160px;
+}
+
 /* Remove margin on the last button */
 .combat-button:last-child {
   margin-right: 0;

--- a/src/Card.js
+++ b/src/Card.js
@@ -1,11 +1,14 @@
 import React from 'react';
 
-function Card({ creature, onCardSelect, isSelected }) {
+function Card({ creature, onCardSelect, isSelected, disabled }) {
   const healthPercent = (creature.currentHealth / creature.maxHealth) * 100;
   const barColor = `hsl(${healthPercent * 1.2}, 70%, 50%)`;
 
   return (
-    <div className={`card ${isSelected ? 'selected' : ''}`} onClick={onCardSelect}>
+    <div
+      className={`card ${isSelected ? 'selected' : ''} ${disabled ? 'disabled' : ''}`}
+      onClick={disabled ? undefined : onCardSelect}
+    >
       <div className="health-bar">
         <div
           className="health-bar-fill"

--- a/src/DeckBuilder.js
+++ b/src/DeckBuilder.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import creatures from './creatures';
 import { DECK_SIZE } from './constants';
+import Card from './Card';
 
 function DeckBuilder({ onDecksSelected }) {
   const [player1Deck, setPlayer1Deck] = useState([]);
@@ -52,15 +53,13 @@ function DeckBuilder({ onDecksSelected }) {
     const isSelected = deck.some(c => c.name === creature.name);
     const disabled = deck.length >= DECK_SIZE && !isSelected;
     return (
-      <label key={`${player}-${creature.name}`} style={{display: 'block'}}>
-        <input
-          type="checkbox"
-          checked={isSelected}
-          disabled={disabled}
-          onChange={() => toggleSelection(player, creature)}
-        />
-        {creature.name}
-      </label>
+      <Card
+        key={`${player}-${creature.name}`}
+        creature={creature}
+        onCardSelect={() => toggleSelection(player, creature)}
+        isSelected={isSelected}
+        disabled={disabled}
+      />
     );
   };
 
@@ -75,15 +74,17 @@ function DeckBuilder({ onDecksSelected }) {
     setPage((page + 1) % totalPages);
 
   return (
-    <div>
+    <div className="deck-builder">
       <h2>Deck Builder</h2>
-      <div style={{display: 'flex', justifyContent: 'space-around'}}>
-        <div>
-          <h3>Player 1</h3>
+      <div>
+        <h3>Player 1</h3>
+        <div className="player-cards">
           {pageCreatures.map(creature => renderCreature(creature, 1))}
         </div>
-        <div>
-          <h3>Player 2</h3>
+      </div>
+      <div>
+        <h3>Player 2</h3>
+        <div className="player-cards">
           {pageCreatures.map(creature => renderCreature(creature, 2))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Render full card components during deck selection with pagination
- Allow card components to be disabled and styled when deck is full
- Add responsive deck builder layout and card styles so all cards fit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68950987ff688323b6ea40d42c9f0983