### PR TITLE
Expand ability system with combat resolution

### DIFF
--- a/src/__tests__/abilities.test.js
+++ b/src/__tests__/abilities.test.js
@@ -1,0 +1,106 @@
+import { combatRound } from '../Game';
+import { ABILITIES } from '../creatures';
+
+describe('ability interactions', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('fire breath increases damage', () => {
+    const attacker = {
+      name: 'Dragon',
+      stats: { strength: 50, agility: 0, intelligence: 0, defense: 0, magic: 0 },
+      abilities: [ABILITIES.FIRE_BREATH],
+      currentHealth: 100,
+      maxHealth: 100,
+    };
+    const defender = {
+      name: 'Dummy',
+      stats: { defense: 0 },
+      currentHealth: 100,
+      maxHealth: 100,
+    };
+    const logFn = jest.fn();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
+    combatRound(attacker, defender, 'Melee', logFn);
+
+    expect(defender.currentHealth).toBe(40); // 50 base +10 ability
+    expect(logFn.mock.calls.some(call => call[0].includes('Fire Breath'))).toBe(true);
+  });
+
+  test('heal restores attacker health', () => {
+    const attacker = {
+      name: 'Forest Spirit',
+      stats: { strength: 50, agility: 0, intelligence: 0, defense: 0, magic: 0 },
+      abilities: [ABILITIES.HEAL],
+      currentHealth: 80,
+      maxHealth: 100,
+    };
+    const defender = {
+      name: 'Dummy',
+      stats: { defense: 0 },
+      currentHealth: 100,
+      maxHealth: 100,
+    };
+    const logFn = jest.fn();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
+    combatRound(attacker, defender, 'Melee', logFn);
+
+    expect(attacker.currentHealth).toBe(90); // healed by 10
+    expect(defender.currentHealth).toBe(50); // base 50 damage
+    expect(logFn.mock.calls.some(call => call[0].includes('Heal'))).toBe(true);
+  });
+
+  test('berserk boosts damage slightly', () => {
+    const attacker = {
+      name: 'Orc',
+      stats: { strength: 50, agility: 0, intelligence: 0, defense: 0, magic: 0 },
+      abilities: [ABILITIES.BERSERK],
+      currentHealth: 100,
+      maxHealth: 100,
+    };
+    const defender = {
+      name: 'Dummy',
+      stats: { defense: 0 },
+      currentHealth: 100,
+      maxHealth: 100,
+    };
+    const logFn = jest.fn();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
+    combatRound(attacker, defender, 'Melee', logFn);
+
+    expect(defender.currentHealth).toBe(45); // 50 base +5 berserk
+    expect(logFn.mock.calls.some(call => call[0].includes('Berserk'))).toBe(true);
+  });
+
+  test('stun prevents next attack', () => {
+    const attacker = {
+      name: 'Troll',
+      stats: { strength: 50, agility: 0, intelligence: 0, defense: 0, magic: 0 },
+      abilities: [ABILITIES.STUN],
+      currentHealth: 100,
+      maxHealth: 100,
+    };
+    const defender = {
+      name: 'Dummy',
+      stats: { strength: 50, agility: 0, intelligence: 0, defense: 0, magic: 0 },
+      abilities: [],
+      currentHealth: 100,
+      maxHealth: 100,
+      isStunned: false,
+    };
+    const logFn = jest.fn();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
+    combatRound(attacker, defender, 'Melee', logFn);
+    expect(defender.isStunned).toBe(true);
+
+    combatRound(defender, attacker, 'Melee', logFn);
+    expect(attacker.currentHealth).toBe(100); // stunned defender deals no damage
+    expect(defender.isStunned).toBe(false); // stun wears off
+    expect(logFn.mock.calls.some(call => call[0].includes('stunned'))).toBe(true);
+  });
+});

--- a/src/creatures.js
+++ b/src/creatures.js
@@ -1,3 +1,11 @@
+export const ABILITIES = {
+  FIRE_BREATH: 'fire_breath',
+  HEAL: 'heal',
+  BERSERK: 'berserk',
+  SHIELD_WALL: 'shield_wall',
+  STUN: 'stun',
+};
+
 const creatures = [
   {
     name: 'Dragon',
@@ -10,7 +18,7 @@ const creatures = [
       defense: 85,
       magic: 80
     },
-    abilities: ['fire_breath', 'fly'],
+    abilities: [ABILITIES.FIRE_BREATH, 'fly'],
     currentHealth: 500,
     maxHealth: 500,
     statusEffects: [],
@@ -27,7 +35,7 @@ const creatures = [
       defense: 75,
       magic: 30
     },
-    abilities: ['berserk', 'shield_wall'],
+    abilities: [ABILITIES.BERSERK, ABILITIES.SHIELD_WALL],
     currentHealth: 400,
     maxHealth: 400,
     statusEffects: [],
@@ -78,7 +86,7 @@ const creatures = [
       defense: 70,
       magic: 55
     },
-    abilities: ['soul_reap', 'shield_bash'],
+    abilities: ['soul_reap', ABILITIES.STUN],
     currentHealth: 450,
     maxHealth: 450,
     statusEffects: [],
@@ -95,7 +103,7 @@ const creatures = [
       defense: 60,
       magic: 90
     },
-    abilities: ['heal', 'entangle'],
+    abilities: [ABILITIES.HEAL, ABILITIES.STUN],
     currentHealth: 350,
     maxHealth: 350,
     statusEffects: [],
@@ -112,7 +120,7 @@ const creatures = [
       defense: 80,
       magic: 30
     },
-    abilities: ['rage', 'battle_cry'],
+    abilities: [ABILITIES.BERSERK],
     currentHealth: 420,
     maxHealth: 420,
     statusEffects: [],
@@ -129,7 +137,7 @@ const creatures = [
       defense: 65,
       magic: 100
     },
-    abilities: ['rebirth', 'flame_wings'],
+    abilities: [ABILITIES.HEAL, ABILITIES.FIRE_BREATH],
     currentHealth: 380,
     maxHealth: 380,
     statusEffects: [],
@@ -146,7 +154,7 @@ const creatures = [
       defense: 75,
       magic: 25
     },
-    abilities: ['regenerate', 'club_slam'],
+    abilities: [ABILITIES.HEAL, ABILITIES.STUN],
     currentHealth: 430,
     maxHealth: 430,
     statusEffects: [],
@@ -180,7 +188,7 @@ const creatures = [
       defense: 80,
       magic: 35
     },
-    abilities: ['charge', 'horn_strike'],
+    abilities: [ABILITIES.BERSERK, ABILITIES.STUN],
     currentHealth: 410,
     maxHealth: 410,
     statusEffects: [],
@@ -197,7 +205,7 @@ const creatures = [
       defense: 85,
       magic: 90
     },
-    abilities: ['elemental_shield', 'light_beam'],
+    abilities: [ABILITIES.SHIELD_WALL, 'light_beam'],
     currentHealth: 400,
     maxHealth: 400,
     statusEffects: [],
@@ -248,7 +256,7 @@ const creatures = [
       defense: 60,
       magic: 30
     },
-    abilities: ['poison_bite', 'web_sling'],
+    abilities: ['poison_bite', ABILITIES.STUN],
     currentHealth: 300,
     maxHealth: 300,
     statusEffects: [],
@@ -265,7 +273,7 @@ const creatures = [
       defense: 90,
       magic: 110
     },
-    abilities: ['divine_heal', 'light_breath'],
+    abilities: [ABILITIES.HEAL, ABILITIES.FIRE_BREATH],
     currentHealth: 550,
     maxHealth: 550,
     statusEffects: [],
@@ -316,7 +324,7 @@ const creatures = [
       defense: 60,
       magic: 50
     },
-    abilities: ['spear_thrust', 'shield_wall'],
+    abilities: ['spear_thrust', ABILITIES.SHIELD_WALL],
     currentHealth: 300,
     maxHealth: 300,
     statusEffects: [],
@@ -367,7 +375,7 @@ const creatures = [
       defense: 40,
       magic: 95
     },
-    abilities: ['flame_burst', 'burn'],
+    abilities: [ABILITIES.FIRE_BREATH, 'burn'],
     currentHealth: 320,
     maxHealth: 320,
     statusEffects: [],
@@ -384,7 +392,7 @@ const creatures = [
       defense: 50,
       magic: 90
   },
-    abilities: ['water_blast', 'healing_surge'],
+    abilities: ['water_blast', ABILITIES.HEAL],
     currentHealth: 300,
     maxHealth: 300,
     statusEffects: [],
@@ -401,7 +409,7 @@ const creatures = [
       defense: 90,
       magic: 70
     },
-    abilities: ['rock_throw', 'earth_shield'],
+    abilities: ['rock_throw', ABILITIES.SHIELD_WALL],
     currentHealth: 380,
     maxHealth: 380,
     statusEffects: [],
@@ -418,7 +426,7 @@ const creatures = [
       defense: 40,
       magic: 80
     },
-    abilities: ['gust_of_wind', 'whirlwind'],
+    abilities: ['gust_of_wind', ABILITIES.STUN],
     currentHealth: 290,
     maxHealth: 290,
     statusEffects: [],
@@ -435,7 +443,7 @@ const creatures = [
       defense: 45,
       magic: 85
     },
-    abilities: ['lightning_bolt', 'shock'],
+    abilities: [ABILITIES.STUN],
     currentHealth: 310,
     maxHealth: 310,
     statusEffects: [],


### PR DESCRIPTION
## Summary
- add stun to standardized ability constants and map several creature abilities to shared mechanics like heal and berserk
- extend resolveAbility and combatRound so berserk boosts damage and stun skips an attack
- cover berserk and stun interactions with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951509b0348323b0ec78b7dadca9a6