### PR TITLE
Add single-player AI mode and tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import { DECK_SIZE } from './constants';
 import './App.css';
 
 function App() {
-  const [mode, setMode] = useState(null); // 'random' or 'custom'
+  const [players, setPlayers] = useState(null); // 1 or 2 players
   const [player1Deck, setPlayer1Deck] = useState([]);
   const [player2Deck, setPlayer2Deck] = useState([]);
 
@@ -14,7 +14,7 @@ function App() {
     setPlayer2Deck(p2);
   };
 
-  if (mode === 'custom' && (player1Deck.length !== DECK_SIZE || player2Deck.length !== DECK_SIZE)) {
+  if (players === 2 && (player1Deck.length !== DECK_SIZE || player2Deck.length !== DECK_SIZE)) {
     return (
       <div className="App">
         <DeckBuilder onDecksSelected={handleDecksSelected} />
@@ -24,15 +24,15 @@ function App() {
 
   return (
     <div className="App">
-      {mode === null && (
+      {players === null && (
         <div>
-          <h2>Select Game Mode</h2>
-          <button onClick={() => setMode('random')}>Random Decks</button>
-          <button onClick={() => setMode('custom')}>Choose Decks</button>
+          <h2>Select Players</h2>
+          <button onClick={() => setPlayers(1)}>1 player</button>
+          <button onClick={() => setPlayers(2)}>2 players</button>
         </div>
       )}
-      {mode === 'random' && <Game />}
-      {mode === 'custom' && player1Deck.length === DECK_SIZE && player2Deck.length === DECK_SIZE && (
+      {players === 1 && <Game singlePlayer />}
+      {players === 2 && player1Deck.length === DECK_SIZE && player2Deck.length === DECK_SIZE && (
         <Game player1Deck={player1Deck} player2Deck={player2Deck} />
       )}
     </div>

--- a/src/__tests__/ai.test.js
+++ b/src/__tests__/ai.test.js
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Game from '../Game';
+
+const createCard = (name, stats) => ({
+  name,
+  image: '',
+  stats: {
+    strength: stats.strength || 0,
+    agility: stats.agility || 0,
+    intelligence: 0,
+    defense: 0,
+    magic: stats.magic || 0,
+  },
+  abilities: [],
+  currentHealth: 100,
+  maxHealth: 100,
+});
+
+test('AI selects highest stat card and style', async () => {
+  const player1Deck = [
+    createCard('Hero', { strength: 5, agility: 5, magic: 5 }),
+    createCard('Spare1', { strength: 4, agility: 4, magic: 4 }),
+    createCard('Spare2', { strength: 3, agility: 3, magic: 3 }),
+  ];
+  const player2Deck = [
+    createCard('Warrior', { strength: 10, agility: 1, magic: 1 }),
+    createCard('Archer', { strength: 1, agility: 8, magic: 1 }),
+    createCard('Mage', { strength: 1, agility: 1, magic: 12 }),
+  ];
+
+  jest.spyOn(Math, 'random').mockReturnValue(0);
+
+  render(
+    <Game
+      player1Deck={player1Deck}
+      player2Deck={player2Deck}
+      singlePlayer
+    />
+  );
+
+  fireEvent.click(screen.getByText('Hero'));
+  fireEvent.click(screen.getAllByText('Melee')[0]);
+
+  await waitFor(() => {
+    const aiMagicBtn = screen.getAllByText('Magic')[1].closest('button');
+    expect(aiMagicBtn.classList.contains('selected')).toBe(true);
+    const mageCard = screen.getByText('Mage').closest('.card');
+    expect(mageCard.classList.contains('selected')).toBe(true);
+  });
+
+  const fightBtn = screen.getByText(/Fight/i);
+  expect(fightBtn.disabled).toBe(false);
+  fireEvent.click(fightBtn);
+
+  await waitFor(() => {
+    expect(screen.queryByText(/Round 1/i)).not.toBeNull();
+  });
+
+  Math.random.mockRestore();
+});

--- a/src/__tests__/ai.test.js
+++ b/src/__tests__/ai.test.js
@@ -58,3 +58,28 @@ test('AI selects highest stat card and style', async () => {
 
   Math.random.mockRestore();
 });
+
+test('AI does not act in two player mode', async () => {
+  const player1Deck = [
+    createCard('Hero', { strength: 5, agility: 5, magic: 5 }),
+    createCard('Spare1', { strength: 4, agility: 4, magic: 4 }),
+    createCard('Spare2', { strength: 3, agility: 3, magic: 3 }),
+  ];
+  const player2Deck = [
+    createCard('Warrior', { strength: 10, agility: 1, magic: 1 }),
+    createCard('Archer', { strength: 1, agility: 8, magic: 1 }),
+    createCard('Mage', { strength: 1, agility: 1, magic: 12 }),
+  ];
+
+  render(<Game player1Deck={player1Deck} player2Deck={player2Deck} />);
+
+  fireEvent.click(screen.getByText('Hero'));
+  fireEvent.click(screen.getAllByText('Melee')[0]);
+
+  await waitFor(() => {
+    const aiMagicBtn = screen.getAllByText('Magic')[1].closest('button');
+    expect(aiMagicBtn.classList.contains('selected')).toBe(false);
+    const fightBtn = screen.getByText(/Fight/i);
+    expect(fightBtn.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `singlePlayer` flag and AI decision logic
- disable player two inputs and show AI moves
- test AI selections and combat flow

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6895ea94b5508323aa70133aebc57882